### PR TITLE
Do not interpret a1z26 code as words

### DIFF
--- a/src/decoder/cryptoUtilities.ts
+++ b/src/decoder/cryptoUtilities.ts
@@ -193,6 +193,7 @@ export const isWord = (word: string): boolean => {
   const wordPattern = /[a-z']+/g;
   return [...word.toLowerCase().matchAll(wordPattern)].reduce(
     (prev, item) => prev && Reflect.get(words, item[0]),
-    true
+    // We want untranslated pieces of an a1z26 cipher to fail right away
+    !/[\d-]+/.test(word)
   );
 };


### PR DESCRIPTION
Prevent a1z26 untranslated code from being recognized as a valid word